### PR TITLE
Check for object existence in replaceChild function

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -475,6 +475,9 @@ Class extension_author_roles extends Extension
 	// name matches the name of the second argument with
 	// the second argument
 	private static function replaceChild($parent, $child) {
+		
+		if(!is_array($child)) return false;
+		
 		foreach($parent->getChildren() as $position => $oldChild) {
 			if($oldChild->getName() == $child->getName()) {
 				$parent->replaceChildAt($position,$child);

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -476,7 +476,9 @@ Class extension_author_roles extends Extension
 	// the second argument
 	private static function replaceChild($parent, $child) {
 		
-		if(!is_array($child)) return false;
+		if(!is_array($child)) {
+    			$child = array($child);
+		}
 		
 		foreach($parent->getChildren() as $position => $oldChild) {
 			if($oldChild->getName() == $child->getName()) {

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -24,5 +24,8 @@
 			to Symphony to make sure the 'Author Roles'-extension is executed as last, after all other extensions have
 			made their possible modifications to the navigation. Read the readme for more details.
 		</release>
+		<release version="1.3" date="2016-01-26" min="2.3">
+			Bugfix for replaceChild function not returning an array.
+		</release>
 	</releases>
 </extension>


### PR DESCRIPTION
I needed to add a check for the existence of the $child object before the loop is run. Not sure if this is correctly implemented? but it works for me once I corrected this small error.
